### PR TITLE
Move NodeJS to v8 + tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:16.04
 
 MAINTAINER David Razdolski, <admin@unreliable.site>
 
+    # Initial update & upgrade
 RUN apt update \
     && apt upgrade -y \
     && apt -y install curl software-properties-common locales git \
@@ -12,11 +13,11 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-    # NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    # NodeJS 8
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt -y install nodejs
 
-    # PHP 7.1
+    # PHP 7.2
 RUN add-apt-repository -y ppa:ondrej/php \
     && apt update \
     && apt -y install php7.2 php7.2-cli php7.2-gd php7.2-mysql php7.2-pdo php7.2-mbstring php7.2-tokenizer php7.2-bcmath php7.2-xml php7.2-fpm php7.2-curl php7.2-zip


### PR DESCRIPTION
I figured since a lot of NodeJS bots used discord.js it'd be appropriate to update to NodeJS 8, since it now requires it: https://github.com/discordjs/discord.js